### PR TITLE
Only add properties to command json if they are defined

### DIFF
--- a/src/classes/BaseCommand.ts
+++ b/src/classes/BaseCommand.ts
@@ -66,7 +66,7 @@ export abstract class BaseCommand<T extends Client = Client> implements APIAppli
 	 */
 	public toJSON(): ApplicationCommand {
 		const { name, description, options, defaultPermission = true } = this;
-		return { name, description, default_permission: defaultPermission, options: this.mapOptions(options) };
+		return { name, description, default_permission: defaultPermission, ...(this.mapOptions(options) && { options: this.mapOptions(options) }) };
 	}
 
 	/**
@@ -79,9 +79,9 @@ export abstract class BaseCommand<T extends Client = Client> implements APIAppli
 		//	@ts-ignore
 		return options?.map(({type, name, description, required, choices, options}) => ({
 			type, name, description,
-			required: required ?? undefined,
-			choices: choices ?? undefined,
-			options: this.mapOptions(options, false),
+			...(required && { required: required }),
+			...(choices && { choices: choices }),
+			...(this.mapOptions(options, false) && { options: this.mapOptions(options, false) }),
 		})) ?? (defined ? [] : undefined);
 	}
 }


### PR DESCRIPTION
Discord only returns objects where the properties are defined. It would  be possible to add the properties recursively for the options & commands yet this sounds like a lot more work than just not adding the properties to the command json if they aren't defined.

- [x] Commands can still be created
- [x] Commands can still be updated
- [x] Commands can still be deleted

Feel free to show alternatives, I don't think this is an ideal solution but it did seem to fix my issues.